### PR TITLE
Fix code scanning alert no. 8: Expression language injection (Spring)

### DIFF
--- a/src/main/java/io/shiftleft/controller/SearchController.java
+++ b/src/main/java/io/shiftleft/controller/SearchController.java
@@ -23,7 +23,8 @@ public class SearchController {
     try {
       ExpressionParser parser = new SpelExpressionParser();
       Expression exp = parser.parseExpression(foo);
-      message = (Object) exp.getValue();
+      SimpleEvaluationContext context = SimpleEvaluationContext.forReadWriteDataBinding().build();
+      message = (Object) exp.getValue(context);
     } catch (Exception ex) {
       System.out.println(ex.getMessage());
     }


### PR DESCRIPTION
Fixes [https://github.com/beth-linker/shiftleft-java-demo/security/code-scanning/8](https://github.com/beth-linker/shiftleft-java-demo/security/code-scanning/8)

To fix the problem, we need to ensure that the user-provided input is not evaluated in a powerful context that allows arbitrary method invocation. Instead, we should use a `SimpleEvaluationContext` that restricts the capabilities of the SpEL expression.

1. Modify the `doGetSearch` method to use `SimpleEvaluationContext` for evaluating the SpEL expression.
2. Ensure that the `SimpleEvaluationContext` is configured to allow only read/write data binding without method invocation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
